### PR TITLE
Derive Clone and Copy for EspTwaiFrame

### DIFF
--- a/esp-hal-common/src/twai/mod.rs
+++ b/esp-hal-common/src/twai/mod.rs
@@ -93,7 +93,7 @@ use crate::{
 pub mod filter;
 
 /// Structure backing the embedded_hal::can::Frame/embedded_can::Frame trait.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct EspTwaiFrame {
     id: Id,
     dlc: usize,


### PR DESCRIPTION
I want to create a queue of `EspTwaiFrame`s, but it's really awkward since it does not implement Clone or Copy.

I tested on a esp32-c3.
